### PR TITLE
"fix typo in description entry"

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -24,7 +24,7 @@ sessions_parser = reqparse.RequestParser()
 sessions_parser.add_argument("session_h", type=str)
 sessions_parser.add_argument("run_date", type=str)
 sessions_parser.add_argument("scm_ref", type=str)
-sessions_parser.add_argument("descriptio", type=str)
+sessions_parser.add_argument("description", type=str)
 
 metrics_parser = reqparse.RequestParser()
 metrics_parser.add_argument("session_h", type=str)

--- a/api/test/__init__.py
+++ b/api/test/__init__.py
@@ -24,7 +24,7 @@ sessions_parser = reqparse.RequestParser()
 sessions_parser.add_argument("session_h", type=str)
 sessions_parser.add_argument("run_date", type=str)
 sessions_parser.add_argument("scm_ref", type=str)
-sessions_parser.add_argument("descriptio", type=str)
+sessions_parser.add_argument("description", type=str)
 
 metrics_parser = reqparse.RequestParser()
 metrics_parser.add_argument("session_h", type=str)

--- a/api/test/test_api.py
+++ b/api/test/test_api.py
@@ -32,7 +32,7 @@ class ApiTest(unittest.TestCase):
             "session_h": "c2c5b0d5d3c799ce9fc174451609f47f",
             "run_date": "2021-05-07T01:16:59.032413",
             "scm_ref": "2cc4cdda54450ca99a340c2c309f1fc19579d78b",
-            "descriptio": None}
+            "description": None}
 
         self.metric_post = {
             "session_h": "c2c5b0d5d3c799ce9fc174451609f47f",


### PR DESCRIPTION
Descriptions are not well handled. I guess this is due to a typo in the corresponding field. This commit fixes this issue.